### PR TITLE
Feature/ar 562 customize template to fit more scenarios 06 2021

### DIFF
--- a/public/fixtures/image-text/slide1.json
+++ b/public/fixtures/image-text/slide1.json
@@ -1,23 +1,21 @@
 {
-  "id": "textBox1",
+  "id": "imageText1",
   "title": "Slide 1",
   "template": "template-image-text",
-  "duration": 500000,
+  "duration": 4000,
   "content": {
     "title": "Slide 1",
     "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.",
-    "media": [
-      {
-        "id": "uniqueMedia1",
-        "url": "./fixtures/images/mountain1.jpeg"
-      }
-    ],
+    "media": {
+      "id": "uniqueMedia1",
+      "url": "./fixtures/images/mountain1.jpeg"
+    },
     "styling": {
       "boxAlign": "top",
-      "boxMargin": true,
-      "separator": true,
-      "halfSize": true,
-      "reversed": true
+      "boxMargin": false,
+      "separator": false,
+      "halfSize": false,
+      "reversed": false
     }
   }
 }

--- a/public/fixtures/image-text/slide1.json
+++ b/public/fixtures/image-text/slide1.json
@@ -2,7 +2,7 @@
   "id": "textBox1",
   "title": "Slide 1",
   "template": "template-image-text",
-  "duration": 15000,
+  "duration": 500000,
   "content": {
     "title": "Slide 1",
     "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.",
@@ -12,6 +12,12 @@
         "url": "./fixtures/images/mountain1.jpeg"
       }
     ],
-    "boxAlign": "top"
+    "styling": {
+      "boxAlign": "top",
+      "boxMargin": true,
+      "separator": true,
+      "halfSize": true,
+      "reversed": true
+    }
   }
 }

--- a/public/fixtures/image-text/slide10.json
+++ b/public/fixtures/image-text/slide10.json
@@ -1,20 +1,20 @@
 {
-  "id": "imageText3",
-  "title": "Slide 3",
+  "id": "imageText10",
+  "title": "Slide 10 margin and separator",
   "template": "template-image-text",
-  "duration": 15000,
+  "duration": 4000,
   "content": {
-    "title": "Slide 3",
+    "title": "Slide 10",
     "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.",
     "media": {
-      "id": "uniqueMedia3",
-      "url": "./fixtures/images/mountain3.jpeg"
+      "id": "uniqueMedia1",
+      "url": "./fixtures/images/mountain4.jpeg"
     },
     "styling": {
-      "boxAlign": "right",
-      "boxMargin": false,
-      "separator": false,
-      "halfSize": false,
+      "boxAlign": "top",
+      "boxMargin": true,
+      "separator": true,
+      "halfSize": true,
       "reversed": false
     }
   }

--- a/public/fixtures/image-text/slide11.json
+++ b/public/fixtures/image-text/slide11.json
@@ -1,21 +1,21 @@
 {
-  "id": "imageText3",
-  "title": "Slide 3",
+  "id": "imageText11",
+  "title": "Slide 11 reversed",
   "template": "template-image-text",
-  "duration": 15000,
+  "duration": 4000,
   "content": {
-    "title": "Slide 3",
+    "title": "Slide 11",
     "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.",
     "media": {
-      "id": "uniqueMedia3",
-      "url": "./fixtures/images/mountain3.jpeg"
+      "id": "uniqueMedia1",
+      "url": "./fixtures/images/mountain4.jpeg"
     },
     "styling": {
-      "boxAlign": "right",
+      "boxAlign": "top",
       "boxMargin": false,
-      "separator": false,
-      "halfSize": false,
-      "reversed": false
+      "separator": true,
+      "halfSize": true,
+      "reversed": true
     }
   }
 }

--- a/public/fixtures/image-text/slide12.json
+++ b/public/fixtures/image-text/slide12.json
@@ -1,0 +1,12 @@
+{
+  "id": "imageText12",
+  "title": "Slide 12 just image",
+  "template": "template-image-text",
+  "duration": 4000,
+  "content": {
+    "media": {
+      "id": "uniqueMedia1",
+      "url": "./fixtures/images/mountain4.jpeg"
+    }
+  }
+}

--- a/public/fixtures/image-text/slide2.json
+++ b/public/fixtures/image-text/slide2.json
@@ -1,23 +1,21 @@
 {
-  "id": "textBox2",
+  "id": "imageText2",
   "title": "Slide 2",
   "template": "template-image-text",
   "duration": 15000,
   "content": {
     "title": "Slide 2",
     "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.",
-    "media": [
-      {
-        "id": "uniqueMedia2",
-        "url": "./fixtures/images/mountain2.jpeg"
-      }
-    ],
+    "media": {
+      "id": "uniqueMedia2",
+      "url": "./fixtures/images/mountain2.jpeg"
+    },
     "styling": {
       "boxAlign": "left",
       "boxMargin": false,
-      "separator": true,
-      "halfSize": true
-
+      "separator": false,
+      "halfSize": false,
+      "reversed": false
     }
   }
 }

--- a/public/fixtures/image-text/slide2.json
+++ b/public/fixtures/image-text/slide2.json
@@ -12,6 +12,12 @@
         "url": "./fixtures/images/mountain2.jpeg"
       }
     ],
-    "boxAlign": "left"
+    "styling": {
+      "boxAlign": "left",
+      "boxMargin": false,
+      "separator": true,
+      "halfSize": true
+
+    }
   }
 }

--- a/public/fixtures/image-text/slide3.json
+++ b/public/fixtures/image-text/slide3.json
@@ -12,6 +12,12 @@
         "url": "./fixtures/images/mountain3.jpeg"
       }
     ],
-    "boxAlign": "right"
+    "styling": {
+      "boxAlign": "right",
+      "boxMargin": true,
+      "separator": true,
+      "halfSize": true
+
+    }
   }
 }

--- a/public/fixtures/image-text/slide4.json
+++ b/public/fixtures/image-text/slide4.json
@@ -12,6 +12,11 @@
         "url": "./fixtures/images/mountain4.jpeg"
       }
     ],
-    "boxAlign": "bottom"
+    "styling": {
+      "boxAlign": "bottom",
+      "boxMargin": false,
+      "halfSize": true
+
+    }
   }
 }

--- a/public/fixtures/image-text/slide4.json
+++ b/public/fixtures/image-text/slide4.json
@@ -1,22 +1,21 @@
 {
-  "id": "textBox4",
+  "id": "imageText4",
   "title": "Slide 4",
   "template": "template-image-text",
   "duration": 15000,
   "content": {
     "title": "Slide 4",
     "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.",
-    "media": [
-      {
-        "id": "uniqueMedia4",
-        "url": "./fixtures/images/mountain4.jpeg"
-      }
-    ],
+    "media": {
+      "id": "uniqueMedia4",
+      "url": "./fixtures/images/mountain4.jpeg"
+    },
     "styling": {
       "boxAlign": "bottom",
       "boxMargin": false,
-      "halfSize": true
-
+      "separator": false,
+      "halfSize": false,
+      "reversed": false
     }
   }
 }

--- a/public/fixtures/image-text/slide5.json
+++ b/public/fixtures/image-text/slide5.json
@@ -1,5 +1,5 @@
 {
-  "id": "textBox5",
+  "id": "imageText5",
   "title": "Slide 5",
   "template": "template-image-text",
   "duration": 15000,
@@ -12,8 +12,9 @@
     "styling": {
       "boxAlign": "bottom",
       "boxMargin": false,
-      "halfSize": true
-
+      "separator": false,
+      "halfSize": false,
+      "reversed": false
     }
   }
 }

--- a/public/fixtures/image-text/slide5.json
+++ b/public/fixtures/image-text/slide5.json
@@ -6,9 +6,14 @@
   "content": {
     "title": "Slide 5",
     "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.",
-    "boxAlign": "bottom",
     "backgroundColor": "rgb(255, 0, 0)",
     "textColor": "rgb(0, 0, 255)",
-    "boxColor": "rgb(0, 255, 0)"
+    "boxColor": "rgb(0, 255, 0)",
+    "styling": {
+      "boxAlign": "bottom",
+      "boxMargin": false,
+      "halfSize": true
+
+    }
   }
 }

--- a/public/fixtures/image-text/slide6.json
+++ b/public/fixtures/image-text/slide6.json
@@ -1,21 +1,22 @@
 {
-  "id": "imageText3",
-  "title": "Slide 3",
+  "id": "imageText6",
+  "title": "Slide 6 fontsize s",
   "template": "template-image-text",
-  "duration": 15000,
+  "duration": 4000,
   "content": {
-    "title": "Slide 3",
+    "title": "Slide 6",
     "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.",
     "media": {
-      "id": "uniqueMedia3",
-      "url": "./fixtures/images/mountain3.jpeg"
+      "id": "uniqueMedia1",
+      "url": "./fixtures/images/mountain1.jpeg"
     },
     "styling": {
-      "boxAlign": "right",
+      "boxAlign": "top",
       "boxMargin": false,
       "separator": false,
       "halfSize": false,
-      "reversed": false
+      "reversed": false,
+      "fontSize": "s"
     }
   }
 }

--- a/public/fixtures/image-text/slide7.json
+++ b/public/fixtures/image-text/slide7.json
@@ -1,21 +1,22 @@
 {
-  "id": "imageText3",
-  "title": "Slide 3",
+  "id": "imageText7",
+  "title": "Slide 7 fontsize m",
   "template": "template-image-text",
-  "duration": 15000,
+  "duration": 4000,
   "content": {
-    "title": "Slide 3",
+    "title": "Slide 7",
     "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.",
     "media": {
-      "id": "uniqueMedia3",
-      "url": "./fixtures/images/mountain3.jpeg"
+      "id": "uniqueMedia1",
+      "url": "./fixtures/images/mountain2.jpeg"
     },
     "styling": {
-      "boxAlign": "right",
+      "boxAlign": "top",
       "boxMargin": false,
       "separator": false,
       "halfSize": false,
-      "reversed": false
+      "reversed": false,
+      "fontSize": "m"
     }
   }
 }

--- a/public/fixtures/image-text/slide8.json
+++ b/public/fixtures/image-text/slide8.json
@@ -1,21 +1,22 @@
 {
-  "id": "imageText3",
-  "title": "Slide 3",
+  "id": "imageText8",
+  "title": "Slide 8 fontsize l",
   "template": "template-image-text",
-  "duration": 15000,
+  "duration": 4000,
   "content": {
-    "title": "Slide 3",
+    "title": "Slide 8",
     "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.",
     "media": {
-      "id": "uniqueMedia3",
+      "id": "uniqueMedia1",
       "url": "./fixtures/images/mountain3.jpeg"
     },
     "styling": {
-      "boxAlign": "right",
+      "boxAlign": "top",
       "boxMargin": false,
       "separator": false,
       "halfSize": false,
-      "reversed": false
+      "reversed": false,
+      "fontSize": "l"
     }
   }
 }

--- a/public/fixtures/image-text/slide9.json
+++ b/public/fixtures/image-text/slide9.json
@@ -1,21 +1,22 @@
 {
-  "id": "imageText3",
-  "title": "Slide 3",
+  "id": "imageText9",
+  "title": "Slide 9 fontsize xl",
   "template": "template-image-text",
-  "duration": 15000,
+  "duration": 4000,
   "content": {
-    "title": "Slide 3",
+    "title": "Slide 9",
     "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.",
     "media": {
-      "id": "uniqueMedia3",
-      "url": "./fixtures/images/mountain3.jpeg"
+      "id": "uniqueMedia1",
+      "url": "./fixtures/images/mountain4.jpeg"
     },
     "styling": {
-      "boxAlign": "right",
+      "boxAlign": "top",
       "boxMargin": false,
       "separator": false,
       "halfSize": false,
-      "reversed": false
+      "reversed": false,
+      "fontSize": "xl"
     }
   }
 }

--- a/public/fixtures/playlist1.json
+++ b/public/fixtures/playlist1.json
@@ -4,22 +4,22 @@
   "slides": [
     {
       "weight": 1,
-      "id": "textBox1",
+      "id": "imageText1",
       "url": "./fixtures/image-text/slide1.json"
     },
     {
       "weight": 2,
-      "id": "textBox2",
+      "id": "imageText2",
       "url": "./fixtures/image-text/slide2.json"
     },
     {
       "weight": 3,
-      "id": "textBox4",
+      "id": "imageText4",
       "url": "./fixtures/image-text/slide4.json"
     },
     {
       "weight": 4,
-      "id": "textBox3",
+      "id": "imageText3",
       "url": "./fixtures/image-text/slide3.json"
     }
   ]

--- a/src/debug-bar.js
+++ b/src/debug-bar.js
@@ -39,26 +39,61 @@ function DebugBar() {
     },
     {
       key: 'debug-bar-fixture-6',
+      title: 'slide: image-text fontsize s',
+      file: './fixtures/image-text/slide6.json'
+    },
+    {
+      key: 'debug-bar-fixture-7',
+      title: 'slide: image-text fontsize m',
+      file: './fixtures/image-text/slide7.json'
+    },
+    {
+      key: 'debug-bar-fixture-8',
+      title: 'slide: image-text fontsize l',
+      file: './fixtures/image-text/slide8.json'
+    },
+    {
+      key: 'debug-bar-fixture-9',
+      title: 'slide: image-text fontsize xl',
+      file: './fixtures/image-text/slide9.json'
+    },
+    {
+      key: 'debug-bar-fixture-10',
+      title: 'slide: margin, separator and half-size',
+      file: './fixtures/image-text/slide10.json'
+    },
+    {
+      key: 'debug-bar-fixture-11',
+      title: 'slide: reversed',
+      file: './fixtures/image-text/slide11.json'
+    },
+    {
+      key: 'debug-bar-fixture-12',
+      title: 'slide: just image',
+      file: './fixtures/image-text/slide12.json'
+    },
+    {
+      key: 'debug-bar-fixture-13',
       title: 'slideshow1',
       file: './fixtures/slideshow/slideshow1.json'
     },
     {
-      key: 'debug-bar-fixture-7',
+      key: 'debug-bar-fixture-14',
       title: 'slideshow2',
       file: './fixtures/slideshow/slideshow2.json'
     },
     {
-      key: 'debug-bar-fixture-8',
+      key: 'debug-bar-fixture-15',
       title: 'calendar1',
       file: './fixtures/calendar/calendar1.json'
     },
     {
-      key: 'debug-bar-fixture-9',
+      key: 'debug-bar-fixture-16',
       title: 'bookreview1',
       file: './fixtures/book-review/book-review1.json'
     },
     {
-      key: 'debug-bar-fixture-10',
+      key: 'debug-bar-fixture-17',
       title: 'meeting-room-schedule',
       file: './fixtures/meeting-room-schedule/meeting-room-schedule.json'
     }

--- a/src/debug-bar.scss
+++ b/src/debug-bar.scss
@@ -28,6 +28,7 @@
   position: absolute;
   bottom: 10px;
   left: 10px;
+  z-index: 2;
 }
 
 .debug-bar-select {

--- a/src/slide.js
+++ b/src/slide.js
@@ -30,6 +30,7 @@ import './slide.scss';
  */
 function Slide({ slide, id, run, slideDone, isNextSlide, prevSlideDuration }) {
   let slideComponent;
+
   if (slide.template === 'template-image-text') {
     slideComponent = <TextBox slide={slide} content={slide.content} run={run} slideDone={slideDone} />;
   } else if (slide.template === 'template-slideshow') {

--- a/src/templates/image-text/image-text.js
+++ b/src/templates/image-text/image-text.js
@@ -65,16 +65,17 @@ function ImageText({ slide, content, run, slideDone }) {
     imageTextStyle.alignSelf = 'flex-end';
   }
 
-
   if (content.styling?.boxMargin) {
     imageTextStyle.margin = '5%';
   }
   if (content.styling?.halfSize) {
     rootClasses = rootClasses.concat(' half-size');
-
   }
   if (content.styling?.separator) {
     rootClasses = rootClasses.concat(' animated-header');
+  }
+  if (content.styling?.reversed) {
+    rootClasses = rootClasses.concat(' reversed');
   }
 
   return (
@@ -113,7 +114,9 @@ ImageText.propTypes = {
       // Accepted values: top, bottom, left, right.
       boxAlign: PropTypes.string,
       boxMargin: PropTypes.bool,
-      separator: PropTypes.bool
+      separator: PropTypes.bool,
+      reversed: PropTypes.bool,
+      halfSize: PropTypes.bool
     })
   }).isRequired
 };

--- a/src/templates/image-text/image-text.js
+++ b/src/templates/image-text/image-text.js
@@ -65,10 +65,14 @@ function ImageText({ slide, content, run, slideDone }) {
     imageTextStyle.alignSelf = 'flex-end';
   }
 
+
   if (content.styling?.boxMargin) {
     imageTextStyle.margin = '5%';
   }
+  if (content.styling?.halfSize) {
+    rootClasses = rootClasses.concat(' half-size');
 
+  }
   if (content.styling?.separator) {
     rootClasses = rootClasses.concat(' animated-header');
   }

--- a/src/templates/image-text/image-text.js
+++ b/src/templates/image-text/image-text.js
@@ -22,6 +22,7 @@ import BaseSlideExecution from '../baseSlideExecution';
 function ImageText({ slide, content, run, slideDone }) {
   const rootStyle = {};
   const imageTextStyle = {};
+  let rootClasses = 'template-image-text';
 
   /**
    * Setup slide run function.
@@ -40,34 +41,49 @@ function ImageText({ slide, content, run, slideDone }) {
   }, [run]);
 
   // Set background image and background color.
-  if (content?.media?.length > 0) {
+  if (content.media?.length > 0) {
     rootStyle.backgroundImage = `url("${content.media[0].url}")`;
   }
-  if (content?.backgroundColor) {
+  if (content.backgroundColor) {
     rootStyle.backgroundColor = content.backgroundColor;
   }
 
   // Set box colors.
-  if (content?.boxColor) {
+  if (content.boxColor) {
     imageTextStyle.backgroundColor = content.boxColor;
   }
-  if (content?.textColor) {
+  if (content.textColor) {
     imageTextStyle.color = content.textColor;
   }
 
   // Position text-box.
-  if (content.boxAlign === 'left' || content.boxAlign === 'right') {
+  if (content.styling?.boxAlign === 'left' || content.styling?.boxAlign === 'right') {
     rootStyle.flexDirection = 'column';
   }
-  if (content?.boxAlign === 'bottom' || content.boxAlign === 'right') {
+
+  if (content.styling?.boxAlign === 'bottom' || content.styling?.boxAlign === 'right') {
     imageTextStyle.alignSelf = 'flex-end';
   }
 
+  if (content.styling?.boxMargin) {
+    imageTextStyle.margin = '5%';
+  }
+
+  if (content.styling?.separator) {
+    rootClasses = rootClasses.concat(' animated-header');
+  }
+
   return (
-    <div className="template-image-text" style={rootStyle}>
+    <div className={rootClasses} style={rootStyle}>
       {content.title && content.text && (
         <div className="box" style={imageTextStyle}>
-          {content.title && <h1 className="headline">{content.title}</h1>}
+          {content.title && (
+            <h1>
+              {content.title}
+              {/* Todo theme the color of the below */}
+              {content.styling?.separator && <div className="separator" style={{ backgroundColor: '#ee0043' }} />}
+            </h1>
+          )}
           {content.text && <div className="text">{content.text}</div>}
         </div>
       )}
@@ -86,11 +102,15 @@ ImageText.propTypes = {
     title: PropTypes.string,
     text: PropTypes.string,
     media: PropTypes.arrayOf(PropTypes.shape({ url: PropTypes.string })),
-    // Accepted values: top, bottom, left, right.
-    boxAlign: PropTypes.string,
     backgroundColor: PropTypes.string,
     textColor: PropTypes.string,
-    boxColor: PropTypes.string
+    boxColor: PropTypes.string,
+    styling: PropTypes.shape({
+      // Accepted values: top, bottom, left, right.
+      boxAlign: PropTypes.string,
+      boxMargin: PropTypes.bool,
+      separator: PropTypes.bool
+    })
   }).isRequired
 };
 

--- a/src/templates/image-text/image-text.js
+++ b/src/templates/image-text/image-text.js
@@ -22,15 +22,20 @@ import BaseSlideExecution from '../baseSlideExecution';
 function ImageText({ slide, content, run, slideDone }) {
   const rootStyle = {};
   const imageTextStyle = {};
-  let rootClasses = 'template-image-text';
 
+  const { separator, boxAlign, reversed, boxMargin, halfSize, fontSize } = content.styling || {};
+  const { title, text, textColor, boxColor, backgroundColor } = content;
+  const { duration } = slide;
+  const displaySeparator = separator && !reversed;
+  let rootClasses = 'template-image-text';
+  const boxClasses = fontSize ? `box ${fontSize}` : 'box';
   /**
    * Setup slide run function.
    */
   const slideExecution = new BaseSlideExecution(slide, slideDone);
   useEffect(() => {
     if (run) {
-      slideExecution.start(slide.duration);
+      slideExecution.start(duration);
     } else {
       slideExecution.stop();
     }
@@ -41,55 +46,54 @@ function ImageText({ slide, content, run, slideDone }) {
   }, [run]);
 
   // Set background image and background color.
-  if (content.media?.length > 0) {
-    rootStyle.backgroundImage = `url("${content.media[0].url}")`;
+  if (content.media?.url) {
+    rootStyle.backgroundImage = `url("${content.media?.url}")`;
   }
-  if (content.backgroundColor) {
-    rootStyle.backgroundColor = content.backgroundColor;
+  if (backgroundColor) {
+    rootStyle.backgroundColor = backgroundColor;
   }
 
   // Set box colors.
-  if (content.boxColor) {
-    imageTextStyle.backgroundColor = content.boxColor;
+  if (boxColor) {
+    imageTextStyle.backgroundColor = boxColor;
   }
-  if (content.textColor) {
-    imageTextStyle.color = content.textColor;
+  if (textColor) {
+    imageTextStyle.color = textColor;
   }
 
   // Position text-box.
-  if (content.styling?.boxAlign === 'left' || content.styling?.boxAlign === 'right') {
-    rootStyle.flexDirection = 'column';
+  if (boxAlign === 'left' || boxAlign === 'right') {
+    rootClasses = rootClasses.concat(' column');
   }
 
-  if (content.styling?.boxAlign === 'bottom' || content.styling?.boxAlign === 'right') {
-    imageTextStyle.alignSelf = 'flex-end';
+  if (boxAlign === 'bottom' || boxAlign === 'right') {
+    rootClasses = rootClasses.concat(' flex-end');
   }
-
-  if (content.styling?.boxMargin) {
-    imageTextStyle.margin = '5%';
+  if (reversed) {
+    rootClasses = rootClasses.concat(' reversed');
   }
-  if (content.styling?.halfSize) {
+  if (boxMargin || reversed) {
+    rootClasses = rootClasses.concat(' box-margin');
+  }
+  if (halfSize && !reversed) {
     rootClasses = rootClasses.concat(' half-size');
   }
-  if (content.styling?.separator) {
+  if (separator && !reversed) {
     rootClasses = rootClasses.concat(' animated-header');
-  }
-  if (content.styling?.reversed) {
-    rootClasses = rootClasses.concat(' reversed');
   }
 
   return (
     <div className={rootClasses} style={rootStyle}>
-      {content.title && content.text && (
-        <div className="box" style={imageTextStyle}>
-          {content.title && (
+      {title && text && (
+        <div className={boxClasses} style={imageTextStyle}>
+          {title && (
             <h1>
-              {content.title}
+              {title}
               {/* Todo theme the color of the below */}
-              {content.styling?.separator && <div className="separator" style={{ backgroundColor: '#ee0043' }} />}
+              {displaySeparator && <div className="separator" style={{ backgroundColor: '#ee0043' }} />}
             </h1>
           )}
-          {content.text && <div className="text">{content.text}</div>}
+          {text && <div className="text">{text}</div>}
         </div>
       )}
     </div>
@@ -106,7 +110,7 @@ ImageText.propTypes = {
   content: PropTypes.shape({
     title: PropTypes.string,
     text: PropTypes.string,
-    media: PropTypes.arrayOf(PropTypes.shape({ url: PropTypes.string })),
+    media: PropTypes.shape({ url: PropTypes.string }),
     backgroundColor: PropTypes.string,
     textColor: PropTypes.string,
     boxColor: PropTypes.string,
@@ -116,7 +120,8 @@ ImageText.propTypes = {
       boxMargin: PropTypes.bool,
       separator: PropTypes.bool,
       reversed: PropTypes.bool,
-      halfSize: PropTypes.bool
+      halfSize: PropTypes.bool,
+      fontSize: PropTypes.string
     })
   }).isRequired
 };

--- a/src/templates/image-text/image-text.scss
+++ b/src/templates/image-text/image-text.scss
@@ -19,11 +19,51 @@
     align-self: auto;
     background-color: beige;
     color: black;
-    margin: 5%;
     width: 40%;
 
     h1 {
       margin-top: 0;
     }
+  }
+
+  &.animated-header {
+    h1 {
+      position: relative;
+      display: inline-block;
+      padding-bottom: 2%;
+
+      .separator {
+        opacity: 0;
+        position: absolute;
+        height: 0.2em;
+        width: 100%;
+        transition: width 0.3s ease-out;
+        animation: 0.7s normal 0.5s forwards 1 h1-underline ease-out;
+      }
+    }
+  }
+}
+
+@keyframes h1-underline {
+  0% {
+    opacity: 0;
+    width: 100%;
+  }
+  40% {
+    opacity: 1;
+    width: 100%;
+    margin-top: 0.938em;
+    height: 0.375em;
+  }
+  70% {
+    opacity: 1;
+    width: 100%;
+    margin-top: 0.625em;
+    height: 0.2em;
+  }
+  100% {
+    opacity: 1;
+    width: 5em;
+    margin-top: 0.625em;
   }
 }

--- a/src/templates/image-text/image-text.scss
+++ b/src/templates/image-text/image-text.scss
@@ -1,4 +1,4 @@
-$color-shadow: rgba(0, 0, 0, .26);
+$color-shadow: rgba(0, 0, 0, 0.26);
 $shadow-box: 0 4px 16px $color-shadow;
 
 .template-image-text {
@@ -30,7 +30,7 @@ $shadow-box: 0 4px 16px $color-shadow;
   }
 
   &.animated-header {
-    .box{
+    .box {
       box-shadow: $shadow-box;
     }
     h1 {

--- a/src/templates/image-text/image-text.scss
+++ b/src/templates/image-text/image-text.scss
@@ -48,7 +48,15 @@ $shadow-box: 0 4px 16px $color-shadow;
       }
     }
   }
+  &.half-size{
+    .box{
+
+      flex:none;
+    }
+  }
 }
+
+
 
 @keyframes h1-underline {
   0% {

--- a/src/templates/image-text/image-text.scss
+++ b/src/templates/image-text/image-text.scss
@@ -24,29 +24,43 @@ $shadow-box: 0 4px 16px $color-shadow;
     color: black;
     width: 40%;
 
+    &.s {
+      font-size: 10px;
+    }
+    &.m {
+      font-size: 15px;
+    }
+    &.l {
+      font-size: 20px;
+    }
+    &.xl {
+      font-size: 25px;
+    }
+
     h1 {
       margin-top: 0;
     }
   }
 
-  &.reversed {
-    .separator {
-      display: none;
-    }
+  &.box-margin {
     .box {
-      padding: 0;
-      order: 2;
-      height: 90%;
-      justify-content: space-between;
-      background-color: transparent;
-      box-shadow: none;
-      font-size: 2em;
-      flex: 1 0 auto;
+      margin: 5%;
     }
+  }
 
-    h1 {
-      order: 1;
-      font-size: 3em;
+  &.flex-end {
+    .box {
+      align-self: flex-end;
+    }
+  }
+
+  &.column {
+    flex-direction: column;
+  }
+  &.half-size {
+    .box {
+      box-shadow: $shadow-box;
+      flex: none;
     }
   }
 
@@ -71,10 +85,27 @@ $shadow-box: 0 4px 16px $color-shadow;
       }
     }
   }
-  &.half-size {
+
+  &.reversed {
+    display: flex;
+
+    .text {
+      order: 1;
+    }
+
     .box {
-      box-shadow: $shadow-box;
-      flex: none;
+      flex-direction: column;
+      padding: 0;
+      height: 90%;
+      justify-content: space-between;
+      background-color: transparent;
+      font-size: 2em;
+      display: flex;
+    }
+
+    h1 {
+      order: 2;
+      font-size: 3em;
     }
   }
 }

--- a/src/templates/image-text/image-text.scss
+++ b/src/templates/image-text/image-text.scss
@@ -48,9 +48,9 @@ $shadow-box: 0 4px 16px $color-shadow;
       }
     }
   }
-  &.half-size{
+  &.half-size {
     .box{
-
+      box-shadow: $shadow-box;
       flex:none;
     }
   }

--- a/src/templates/image-text/image-text.scss
+++ b/src/templates/image-text/image-text.scss
@@ -1,3 +1,6 @@
+$color-shadow: rgba(0, 0, 0, .26);
+$shadow-box: 0 4px 16px $color-shadow;
+
 .template-image-text {
   height: 100%;
   width: 100%;
@@ -27,6 +30,9 @@
   }
 
   &.animated-header {
+    .box{
+      box-shadow: $shadow-box;
+    }
     h1 {
       position: relative;
       display: inline-block;

--- a/src/templates/image-text/image-text.scss
+++ b/src/templates/image-text/image-text.scss
@@ -29,9 +29,32 @@ $shadow-box: 0 4px 16px $color-shadow;
     }
   }
 
+  &.reversed {
+    .separator {
+      display: none;
+    }
+    .box {
+      padding: 0;
+      order: 2;
+      height: 90%;
+      justify-content: space-between;
+      background-color: transparent;
+      box-shadow: none;
+      font-size: 2em;
+      flex: 1 0 auto;
+    }
+
+    h1 {
+      order: 1;
+      font-size: 3em;
+    }
+  }
+
   &.animated-header {
     .box {
       box-shadow: $shadow-box;
+      display: flex;
+      flex-direction: column;
     }
     h1 {
       position: relative;
@@ -49,14 +72,12 @@ $shadow-box: 0 4px 16px $color-shadow;
     }
   }
   &.half-size {
-    .box{
+    .box {
       box-shadow: $shadow-box;
-      flex:none;
+      flex: none;
     }
   }
 }
-
-
 
 @keyframes h1-underline {
   0% {

--- a/src/templates/image-text/image-text.test.js
+++ b/src/templates/image-text/image-text.test.js
@@ -2,7 +2,7 @@ describe('Make sure image-text loads', () => {
   it('Should have headline, text and background-image', () => {
     cy.visit('/');
     cy.get('.debug-bar-select').select('slide: image-text top');
-    cy.get('.template-image-text .box .headline').contains('Slide 1');
+    cy.get('.template-image-text .box h1').contains('Slide 1');
     cy.get('.template-image-text .box .text').contains('Lorem ipsum');
     cy.get('.template-image-text')
       .should('have.css', 'background-image')
@@ -34,5 +34,73 @@ describe('Make sure image-text loads', () => {
     cy.get('.template-image-text').should('have.css', 'background-color', 'rgb(255, 0, 0)');
     cy.get('.template-image-text .box').should('have.css', 'background-color', 'rgb(0, 255, 0)');
     cy.get('.template-image-text .box').should('have.css', 'color', 'rgb(0, 0, 255)');
+  });
+
+  it('Should have fontsize s set', () => {
+    cy.visit('/');
+    cy.get('.debug-bar-select').select('slide: image-text fontsize s');
+    cy.get('.template-image-text .box').should('have.css', 'font-size', '10px');
+  });
+
+  it('Should have fontsize m set', () => {
+    cy.visit('/');
+    cy.get('.debug-bar-select').select('slide: image-text fontsize m');
+    cy.get('.template-image-text .box').should('have.css', 'font-size', '15px');
+  });
+
+  it('Should have fontsize l set', () => {
+    cy.visit('/');
+    cy.get('.debug-bar-select').select('slide: image-text fontsize l');
+    cy.get('.template-image-text .box').should('have.css', 'font-size', '20px');
+  });
+
+  it('Should have fontsize xl set', () => {
+    cy.visit('/');
+    cy.get('.debug-bar-select').select('slide: image-text fontsize xl');
+    cy.get('.template-image-text .box').should('have.css', 'font-size', '25px');
+  });
+
+  it('Should have animated separator', () => {
+    cy.visit('/');
+    cy.get('.debug-bar-select').select('slide: margin, separator and half-size');
+    cy.get('.template-image-text .box .separator').should(
+      'have.css',
+      'animation',
+      '0.7s ease-out 0.5s 1 normal forwards running h1-underline'
+    );
+  });
+
+  it('Should have margin', () => {
+    cy.visit('/');
+    cy.get('.debug-bar-select').select('slide: margin, separator and half-size');
+    cy.get('.template-image-text').should('have.class', 'box-margin');
+    cy.get('.template-image-text .box .separator').should(
+      'have.css',
+      'animation',
+      '0.7s ease-out 0.5s 1 normal forwards running h1-underline'
+    );
+  });
+
+  it('Should have half size', () => {
+    cy.visit('/');
+    cy.get('.debug-bar-select').select('slide: margin, separator and half-size');
+    cy.get('.template-image-text').should('have.class', 'half-size');
+  });
+
+  it('Should be reversed', () => {
+    cy.visit('/');
+    cy.get('.debug-bar-select').select('slide: reversed');
+    cy.get('.template-image-text').should('have.class', 'reversed');
+    cy.get('.template-image-text').should('not.have.class', 'half-size');
+    cy.get('.template-image-text').should('not.have.class', 'animated-header');
+    cy.get('.template-image-text').should('have.class', 'box-margin');
+  });
+
+  it('Should have just image', () => {
+    cy.visit('/');
+    cy.get('.debug-bar-select').select('slide: just image');
+    cy.get('.template-image-text')
+      .should('have.css', 'background-image')
+      .and('include', '/fixtures/images/mountain4.jpeg');
   });
 });

--- a/src/templates/image-text/image-text.test.js
+++ b/src/templates/image-text/image-text.test.js
@@ -63,11 +63,7 @@ describe('Make sure image-text loads', () => {
   it('Should have animated separator', () => {
     cy.visit('/');
     cy.get('.debug-bar-select').select('slide: margin, separator and half-size');
-    cy.get('.template-image-text .box .separator').should(
-      'have.css',
-      'animation',
-      '0.7s ease-out 0.5s 1 normal forwards running h1-underline'
-    );
+    cy.get('.template-image-text .box .separator').should('have.css', 'animation');
   });
 
   it('Should have margin', () => {

--- a/src/templates/image-text/image-text.test.js
+++ b/src/templates/image-text/image-text.test.js
@@ -94,6 +94,8 @@ describe('Make sure image-text loads', () => {
     cy.get('.template-image-text').should('not.have.class', 'half-size');
     cy.get('.template-image-text').should('not.have.class', 'animated-header');
     cy.get('.template-image-text').should('have.class', 'box-margin');
+    cy.get('.template-image-text .text').should('have.css', 'order', '1');
+    cy.get('.template-image-text h1').should('have.css', 'order', '2');
   });
 
   it('Should have just image', () => {

--- a/src/templates/image-text/image-text.test.js
+++ b/src/templates/image-text/image-text.test.js
@@ -70,11 +70,6 @@ describe('Make sure image-text loads', () => {
     cy.visit('/');
     cy.get('.debug-bar-select').select('slide: margin, separator and half-size');
     cy.get('.template-image-text').should('have.class', 'box-margin');
-    cy.get('.template-image-text .box .separator').should(
-      'have.css',
-      'animation',
-      '0.7s ease-out 0.5s 1 normal forwards running h1-underline'
-    );
   });
 
   it('Should have half size', () => {


### PR DESCRIPTION
Task: https://jira.itkdev.dk/browse/AR-562

I am implementing support for the following already existing templates: https://github.com/itk-dev/os2display-template-overview/tree/main/image-text

**A bunch of images:**

_Just image_

<img width="1792" alt="Screenshot 2021-06-28 at 12 16 47" src="https://user-images.githubusercontent.com/15377965/123620625-bb628280-d80a-11eb-8ed0-6513d506eab2.png">

_halfsize, h1underline and margin_

<img width="1792" alt="Screenshot 2021-06-28 at 12 14 00" src="https://user-images.githubusercontent.com/15377965/123620294-59a21880-d80a-11eb-81c4-fb26bef4818c.png">

_reversed_

<img width="1792" alt="Screenshot 2021-06-28 at 12 15 51" src="https://user-images.githubusercontent.com/15377965/123620513-9e2db400-d80a-11eb-8c69-91cea5a280da.png">

_different fontsizes_

<img width="1792" alt="Screenshot 2021-06-28 at 12 18 21" src="https://user-images.githubusercontent.com/15377965/123620885-f9f83d00-d80a-11eb-9e5e-b3ae26a1d85b.png">

<img width="1792" alt="Screenshot 2021-06-28 at 12 17 56" src="https://user-images.githubusercontent.com/15377965/123620916-0086b480-d80b-11eb-8722-6bffcf77f565.png">

<img width="1792" alt="Screenshot 2021-06-28 at 12 18 04" src="https://user-images.githubusercontent.com/15377965/123620927-02507800-d80b-11eb-8da3-6c3787960d0c.png">

<img width="1792" alt="Screenshot 2021-06-28 at 12 18 12" src="https://user-images.githubusercontent.com/15377965/123620934-041a3b80-d80b-11eb-80f1-66346f0cc1d1.png">

